### PR TITLE
Review: Implement endpoints to retrieve all documents and a single document

### DIFF
--- a/Domain.Contracts/Repositories/IDocumentRepository.cs
+++ b/Domain.Contracts/Repositories/IDocumentRepository.cs
@@ -10,6 +10,26 @@ namespace Domain.Contracts.Repositories
     /// </summary>
     public interface IDocumentRepository : IRepositoryBase<Document>
     {
+        /// <summary>
+        /// Retrieves a single <see cref="Document"/> entity by its unique identifier. <br/>
+        /// </summary>
+        /// <param name="documentId">The unique identifier of the activity.</param>
+        /// <param name="changeTracking">
+        /// If <c>true</c>, Entity Framework change tracking will be enabled (suitable for updates). <br/>
+        /// </param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The task result contains the 
+        /// matching <see cref="Document"/> or <c>null</c> if not found.
+        /// </returns>
+        Task<Document?> GetByIdAsync(Guid documentId, bool changeTracking = false);
 
+        /// <summary>
+        /// Retrieves all <see cref="Document"/> entities from the data source. <br/>
+        /// </summary>
+        /// <param name="changeTracking">If <c>true</c>, Entity Framework change tracking will be enabled. <br/></param>
+        /// <returns>
+        /// A task representing the asynchronous operation. The task result contains a collection of <see cref="Document"/> entities.
+        /// </returns>
+        Task<IEnumerable<Document>> GetAllAsync(bool changeTracking = false);
     }
 }

--- a/Domain.Models/Exceptions/NotFound/DocumentNotFoundException.cs
+++ b/Domain.Models/Exceptions/NotFound/DocumentNotFoundException.cs
@@ -1,0 +1,20 @@
+﻿namespace Domain.Models.Exceptions.NotFound
+{
+    /// <summary>
+    /// Exception type for cases where an <see cref="Document"/> is not found.
+    /// </summary>
+    public class DocumentNotFoundException : NotFoundException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentNotFoundException"/> class with a specified document ID.
+        /// </summary>
+        public DocumentNotFoundException(Guid documentId)
+            : base($"Document type with Id '{documentId}' was not found.") { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentNotFoundException"/> class with a default message.
+        /// </summary>
+        public DocumentNotFoundException()
+            : base("The requested document was not found.") { }
+    }
+}

--- a/LMS.Infractructure/Data/MapperProfile.cs
+++ b/LMS.Infractructure/Data/MapperProfile.cs
@@ -3,6 +3,7 @@ using Domain.Models.Entities;
 using LMS.Shared.DTOs.ActivityTypeDto;
 using LMS.Shared.DTOs.AuthDtos;
 using LMS.Shared.DTOs.CourseDtos;
+using LMS.Shared.DTOs.DocumentDtos;
 using LMS.Shared.DTOs.LMSActivityDtos;
 using LMS.Shared.DTOs.ModuleDtos;
 using LMS.Shared.DTOs.PaginationDtos;
@@ -41,6 +42,9 @@ public class MapperProfile : Profile
 
         // ActivityType mappings
         CreateMap<ActivityType, ActivityTypeDto>();
+
+        // Document mappings
+        CreateMap<Document, DocumentDto>();
 
         // Pagination mappings
         CreateMap<PaginationMetadata, PaginationMetadataDto>();

--- a/LMS.Infractructure/Repositories/DocumentRepository.cs
+++ b/LMS.Infractructure/Repositories/DocumentRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Domain.Contracts.Repositories;
 using Domain.Models.Entities;
 using LMS.Infractructure.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace LMS.Infractructure.Repositories
 {
@@ -10,8 +11,31 @@ namespace LMS.Infractructure.Repositories
     /// </summary>
     public class DocumentRepository : RepositoryBase<Document>, IDocumentRepository
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LMSActivityRepository"/> class with the specified database context.
+        /// </summary>
+        /// <param name="context">The database context to be used by the repository.</param>
         public DocumentRepository(ApplicationDbContext context) : base(context)
         {
         }
+
+        /// <summary>
+        /// Retrieves a single <see cref="Document"/> entity by its unique identifier.
+        /// </summary>
+        /// <param name="documentId">The unique identifier of the activity.</param>
+        /// <param name="changeTracking">If true, enables change tracking.</param>
+        /// <returns>The activity entity if found; otherwise, null.</returns>
+        public async Task<Document?> GetByIdAsync(Guid documentId, bool changeTracking = false) =>
+            await FindByCondition(a => a.Id == documentId, trackChanges: changeTracking)
+                .FirstOrDefaultAsync();
+
+        /// <summary>
+        /// Retrieves all <see cref="Document"/> entities.
+        /// </summary>
+        /// <param name="changeTracking">If true, enables change tracking.</param>
+        /// <returns>A collection of all documents.</returns>
+        public async Task<IEnumerable<Document>> GetAllAsync(bool changeTracking = false) =>
+            await FindAll(trackChanges: changeTracking)
+                .ToListAsync();
     }
 }

--- a/LMS.Infractructure/Repositories/DocumentRepository.cs
+++ b/LMS.Infractructure/Repositories/DocumentRepository.cs
@@ -12,7 +12,7 @@ namespace LMS.Infractructure.Repositories
     public class DocumentRepository : RepositoryBase<Document>, IDocumentRepository
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LMSActivityRepository"/> class with the specified database context.
+        /// Initializes a new instance of the <see cref="DocumentRepository"/> class with the specified database context.
         /// </summary>
         /// <param name="context">The database context to be used by the repository.</param>
         public DocumentRepository(ApplicationDbContext context) : base(context)

--- a/LMS.Presentation/Controllers/DocumentConroller.cs
+++ b/LMS.Presentation/Controllers/DocumentConroller.cs
@@ -1,0 +1,74 @@
+﻿using LMS.Shared.DTOs.DocumentDtos;
+using LMS.Shared.DTOs.PaginationDtos;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Service.Contracts;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace LMS.Presentation.Controllers
+{
+    /// <summary>
+    /// Controller for managing documents.
+    /// Provides endpoints for retrieving documents and their details.
+    /// </summary>
+    [Route("api/documents")]
+    [ApiController]
+    [Authorize]
+    public class DocumentsController : ControllerBase
+    {
+        private readonly IServiceManager _serviceManager;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentsController"/> class.
+        /// </summary>
+        /// <param name="serviceManager">The service manager for accessing document-related services.</param>
+        public DocumentsController(IServiceManager serviceManager)
+        {
+            _serviceManager = serviceManager;
+        }
+
+        /// <summary>
+        /// Retrieves a specific document by its unique identifier.
+        /// </summary>
+        /// <param name="guid">The unique identifier of the document.</param>
+        /// <returns>A <see cref="DocumentDto"/> representing the document.</returns>
+        /// <response code="200">Returns the document details.</response>
+        /// <response code="404">If no document is found with the specified GUID.</response>
+        /// <response code="401">Unauthorized.</response>
+        /// <response code="403">Forbidden.</response>
+        [HttpGet("{guid}")]
+        [Authorize(Roles = "Teacher,Student")]
+        [SwaggerOperation(
+            Summary = "Get specified document by ID",
+            Description = "Retrieves document details by their unique GUID identifier."
+        )]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DocumentDto))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<DocumentDto>> GetDocument(Guid guid) =>
+            Ok(await _serviceManager.DocumentService.GetByIdAsync(guid));
+
+        /// <summary>
+        /// Retrieves a paginated list of all documents.
+        /// </summary>
+        /// <param name="page">The page number to retrieve (default is 1).</param>
+        /// <param name="pageSize">The number of items per page (default is 10).</param>
+        /// <returns>A paginated list of documents.</returns>
+        /// <response code="200">Returns a paginated list of documents.</response>
+        /// <response code="401">Unauthorized.</response>
+        /// <response code="403">Forbidden.</response>
+        [HttpGet]
+        [Authorize(Roles = "Teacher,Student")]
+        [SwaggerOperation(
+            Summary = "Get all documents",
+            Description = "Retrieves a list of all documents in the system."
+        )]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PaginatedResultDto<DocumentDto>))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<PaginatedResultDto<DocumentDto>>> GetDocuments([FromQuery] int page = 1, [FromQuery] int pageSize = 10) =>
+            Ok(await _serviceManager.DocumentService.GetAllAsync(page, pageSize));
+    }
+}

--- a/LMS.Services/DocumentService.cs
+++ b/LMS.Services/DocumentService.cs
@@ -1,5 +1,10 @@
 ﻿using AutoMapper;
 using Domain.Contracts.Repositories;
+using Domain.Models.Exceptions.NotFound;
+using LMS.Shared.DTOs.DocumentDtos;
+using LMS.Shared.DTOs.LMSActivityDtos;
+using LMS.Shared.DTOs.PaginationDtos;
+using LMS.Shared.Pagination;
 using Service.Contracts;
 
 namespace LMS.Services
@@ -22,6 +27,41 @@ namespace LMS.Services
         {
             _unitOfWork = unitOfWork;
             _mapper = mapper;
+        }
+
+        /// <summary>
+        /// Retrieves a document by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the document.</param>
+        /// <returns>A <see cref="DocumentDto"/> representing the activity.</returns>
+        /// <exception cref="LMSActivityNotFoundException">Thrown if the document is not found.</exception>
+        public async Task<DocumentDto> GetByIdAsync(Guid id)
+        {
+            var activity = await _unitOfWork.LMSActivity.GetByIdAsync(id);
+
+            if (activity is null)
+                throw new DocumentNotFoundException(id);
+
+            return _mapper.Map<DocumentDto>(activity);
+        }
+
+        /// <summary>
+        /// Retrieves a paginated list of all documents.
+        /// </summary>
+        /// <param name="pageNumber">The page number to retrieve.</param>
+        /// <param name="pageSize">The number of items per page.</param>
+        /// <returns>A <see cref="PaginatedResultDto{DocumentDto}"/> containing the paginated list of documents.</returns>
+        public async Task<PaginatedResultDto<DocumentDto>> GetAllAsync(int pageNumber, int pageSize)
+        {
+            var activities = await _unitOfWork.LMSActivity.GetAllAsync();
+
+            var paginatedActivities = activities.ToPaginatedResult(new PagingParameters
+            {
+                PageNumber = pageNumber,
+                PageSize = pageSize
+            });
+
+            return _mapper.Map<PaginatedResultDto<DocumentDto>>(paginatedActivities);
         }
     }
 }

--- a/LMS.Services/DocumentService.cs
+++ b/LMS.Services/DocumentService.cs
@@ -37,12 +37,12 @@ namespace LMS.Services
         /// <exception cref="LMSActivityNotFoundException">Thrown if the document is not found.</exception>
         public async Task<DocumentDto> GetByIdAsync(Guid id)
         {
-            var activity = await _unitOfWork.LMSActivity.GetByIdAsync(id);
+            var document = await _unitOfWork.Document.GetByIdAsync(id);
 
-            if (activity is null)
+            if (document is null)
                 throw new DocumentNotFoundException(id);
 
-            return _mapper.Map<DocumentDto>(activity);
+            return _mapper.Map<DocumentDto>(document);
         }
 
         /// <summary>
@@ -53,15 +53,15 @@ namespace LMS.Services
         /// <returns>A <see cref="PaginatedResultDto{DocumentDto}"/> containing the paginated list of documents.</returns>
         public async Task<PaginatedResultDto<DocumentDto>> GetAllAsync(int pageNumber, int pageSize)
         {
-            var activities = await _unitOfWork.LMSActivity.GetAllAsync();
+            var documents = await _unitOfWork.Document.GetAllAsync();
 
-            var paginatedActivities = activities.ToPaginatedResult(new PagingParameters
+            var paginatedDocuments = documents.ToPaginatedResult(new PagingParameters
             {
                 PageNumber = pageNumber,
                 PageSize = pageSize
             });
 
-            return _mapper.Map<PaginatedResultDto<DocumentDto>>(paginatedActivities);
+            return _mapper.Map<PaginatedResultDto<DocumentDto>>(paginatedDocuments);
         }
     }
 }

--- a/LMS.Shared/DTOs/DocumentDtos/DocumentDto.cs
+++ b/LMS.Shared/DTOs/DocumentDtos/DocumentDto.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LMS.Shared.DTOs.DocumentDtos
+{
+    /// <summary>
+    /// Data Transfer Object (DTO) for <see cref="Document"/>.
+    /// Used to transfer document data without exposing the full entity.
+    /// </summary>
+    public class DocumentDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the document.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the user who owns the document.
+        /// </summary>
+        public string UserId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the associated course ID, if applicable.
+        /// </summary>
+        public Guid? CourseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the associated module ID, if applicable.
+        /// </summary>
+        public Guid? ModuleId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the associated activity ID, if applicable.
+        /// </summary>
+        public Guid? ActivityId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the storage path or URL of the document.
+        /// </summary>
+        public string Path { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the name of the document.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets an optional description of the document.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timestamp when the document was created or last modified.
+        /// </summary>
+        public DateTime TimeStamp { get; set; }
+    }
+
+}

--- a/Service.Contracts/IDocumentService.cs
+++ b/Service.Contracts/IDocumentService.cs
@@ -1,4 +1,8 @@
-﻿namespace Service.Contracts
+﻿using LMS.Shared.DTOs.DocumentDtos;
+using LMS.Shared.DTOs.LMSActivityDtos;
+using LMS.Shared.DTOs.PaginationDtos;
+
+namespace Service.Contracts
 {
     /// <summary>
     /// Service contract for managing documents.
@@ -6,5 +10,19 @@
     /// </summary>
     public interface IDocumentService
     {
+        /// <summary>
+        /// Retrieves an activity by its unique identifier.
+        /// </summary>
+        /// <param name="id">The unique identifier of the activity.</param>
+        /// <returns>A <see cref="DocumentDto"/> representing the document.</returns>
+        Task<DocumentDto> GetByIdAsync(Guid id);
+
+        /// <summary>
+        /// Retrieves a paginated list of all documents.
+        /// </summary>
+        /// <param name="pageNumber">The page number to retrieve.</param>
+        /// <param name="pageSize">The number of items per page.</param>
+        /// <returns>A <see cref="PaginatedResultDto{DocumentDto}"/> containing the paginated list of documents.</returns>
+        Task<PaginatedResultDto<DocumentDto>> GetAllAsync(int pageNumber, int pageSize);
     }
 }

--- a/Service.Contracts/IDocumentService.cs
+++ b/Service.Contracts/IDocumentService.cs
@@ -11,7 +11,7 @@ namespace Service.Contracts
     public interface IDocumentService
     {
         /// <summary>
-        /// Retrieves an activity by its unique identifier.
+        /// Retrieves a document by its unique identifier.
         /// </summary>
         /// <param name="id">The unique identifier of the activity.</param>
         /// <returns>A <see cref="DocumentDto"/> representing the document.</returns>


### PR DESCRIPTION
This PR adds API endpoints for working with documents:

1. GET /api/documents – retrieves a paginated list of all documents.
2. GET /api/documents/{id} – retrieves a single document by its unique identifier. 