### PR TITLE
Review: Implement Enroll and Unenroll student endpoints

### DIFF
--- a/Domain.Contracts/Repositories/ILMSActivityFeedbackRepository.cs
+++ b/Domain.Contracts/Repositories/ILMSActivityFeedbackRepository.cs
@@ -1,0 +1,20 @@
+﻿using Domain.Models.Entities;
+
+namespace Domain.Contracts.Repositories
+{
+    /// <summary>
+    /// Repository contract for managing <see cref="LMSActivityFeedback"/> entities.
+    /// Inherits basic CRUD operations from <see cref="IRepositoryBase{T}"/>.
+    /// Provides methods to retrieve, add, update, and delete feedbacks
+    /// </summary>
+    public interface ILMSActivityFeedbackRepository : IRepositoryBase<LMSActivityFeedback>
+    {
+        /// <summary>
+        /// Deletes all <see cref="LMSActivityFeedback"/> entries associated with a specific user in a specific course.
+        /// </summary>
+        /// <param name="userId">The unique identifier of the user whose feedbacks are being deleted.</param>
+        /// <param name="courseId">The unique identifier of the course whose feedbacks are being deleted.</param>
+        /// <returns>A task that represents the asynchronous delete operation.</returns>
+        Task DeleteAllInCourseByUserId(string userId, Guid courseId);
+    }
+}

--- a/Domain.Contracts/Repositories/IRepositoryBase.cs
+++ b/Domain.Contracts/Repositories/IRepositoryBase.cs
@@ -4,5 +4,5 @@ public interface IRepositoryBase<T>
     void Create(T entity);
     void Update(T entity);
     void Delete(T entity);
-
+    void DeleteRange(IEnumerable<T> entities);
 }

--- a/Domain.Contracts/Repositories/IUnitOfWork.cs
+++ b/Domain.Contracts/Repositories/IUnitOfWork.cs
@@ -32,6 +32,16 @@ public interface IUnitOfWork
     IDocumentRepository Document { get; }
 
     /// <summary>
+    /// Gets the repository for handling <see cref="Models.Entities.LMSActivityFeedback"/> entities.
+    /// </summary>
+    ILMSActivityFeedbackRepository LMSActivityFeedback { get; }
+
+    /// <summary>
+    /// Gets the repository for handling <see cref="Models.Entities.UserCourse"/> entities.
+    /// </summary>
+    IUserCourseRepository UserCourse { get; }
+
+    /// <summary>
     /// Persists all changes made through the repositories in a single transaction.
     /// </summary>
     /// <returns>A task representing the asynchronous save operation.</returns>

--- a/Domain.Contracts/Repositories/IUserCourseRepository.cs
+++ b/Domain.Contracts/Repositories/IUserCourseRepository.cs
@@ -1,0 +1,19 @@
+﻿using Domain.Models.Entities;
+
+namespace Domain.Contracts.Repositories
+{
+    /// <summary>
+    /// Repository contract for managing <see cref="UserCourse"/> entities.
+    /// Inherits basic CRUD operations from <see cref="IRepositoryBase{T}"/>.
+    /// Provides methods to retrieve, add, update, and delete enrollments
+    /// </summary>
+    public interface IUserCourseRepository : IRepositoryBase<UserCourse>
+    {
+        /// <summary>
+        /// Deletes all <see cref="UserCourse"/> entries associated with a specific user.
+        /// </summary>
+        /// <param name="studentId">The unique identifier of the user whose enrollments are being deleted.</param>
+        /// <returns>A task that represents the asynchronous delete operation.</returns>
+        Task DeleteAllByUserId(string studentId);
+    }
+}

--- a/Domain.Contracts/Repositories/IUserRepository.cs
+++ b/Domain.Contracts/Repositories/IUserRepository.cs
@@ -9,18 +9,32 @@ namespace Domain.Contracts.Repositories;
 /// </summary>
 public interface IUserRepository: IRepositoryBase<ApplicationUser>
 {
-	/// <summary>
-	/// Retrieves a single <see cref="ApplicationUser"/> entity by its unique identifier. <br/>
-	/// </summary>
-	/// <param name="userId">The unique identifier of the user.</param>
-	/// <param name="changeTracking">
-	/// If <c>true</c>, Entity Framework change tracking will be enabled (suitable for updates). <br/>
-	/// </param>
-	/// <returns>
-	/// A task that represents the asynchronous operation. The task result contains the 
-	/// matching <see cref="User"/> or <c>null</c> if not found.
-	/// </returns>
-	public Task<ApplicationUser?> GetUserAsync(string userId, bool changeTracking = false);
+    /// <summary>
+    /// Checks if a user belongs to the "Teacher" role. <br/>
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains <c>true</c> if the user is a student; otherwise, <c>false</c>.</returns>
+    Task<bool> IsUserStudentAsync(string userId);
+
+    /// <summary>
+    /// Checks if a user belongs to the "Teacher" role. <br/>
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains <c>true</c> if the user is a teacher; otherwise, <c>false</c>.</returns>
+    Task<bool> IsUserTeacherAsync(string userId);
+
+    /// <summary>
+    /// Retrieves a single <see cref="ApplicationUser"/> entity by its unique identifier. <br/>
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <param name="changeTracking">
+    /// If <c>true</c>, Entity Framework change tracking will be enabled (suitable for updates). <br/>
+    /// </param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the 
+    /// matching <see cref="User"/> or <c>null</c> if not found.
+    /// </returns>
+    public Task<ApplicationUser?> GetUserAsync(string userId, bool changeTracking = false);
 
 	/// <summary>
 	/// Retrieves all <see cref="User"/> entities from the data source. <br/>

--- a/Domain.Models/Exceptions/BadRequest/RoleMismatchException.cs
+++ b/Domain.Models/Exceptions/BadRequest/RoleMismatchException.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Domain.Models.Exceptions.BadRequest
+{
+    /// <summary>
+    /// Exception thrown when there is a role mismatch in the application.
+    /// </summary>
+    public class RoleMismatchException : BadRequestException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoleMismatchException"/> class with a default message.
+        /// </summary>
+        public RoleMismatchException()
+            : base("The user's role does not match the expected role for this operation.") { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RoleMismatchException"/> class with a specified error message.
+        /// </summary>
+        public RoleMismatchException(string message) : base(message) { }
+    }
+}

--- a/LMS.Infractructure/Repositories/LMSActivityFeedbackRepository.cs
+++ b/LMS.Infractructure/Repositories/LMSActivityFeedbackRepository.cs
@@ -1,0 +1,39 @@
+﻿using Domain.Contracts.Repositories;
+using Domain.Models.Entities;
+using LMS.Infractructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LMS.Infractructure.Repositories
+{
+    /// <summary>
+    /// Repository implementation for managing <see cref="LMSActivityFeedback"/> entities.
+    /// </summary>
+    public class LMSActivityFeedbackRepository : RepositoryBase<LMSActivityFeedback>, ILMSActivityFeedbackRepository
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LMSActivityFeedbackRepository"/> class with the specified database context.
+        /// </summary>
+        /// <param name="context">The database context to be used by the repository.</param>
+        public LMSActivityFeedbackRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Deletes all <see cref="LMSActivityFeedback"/> entries associated with a specific user in a specific course.
+        /// </summary>
+        /// <param name="userId">The unique identifier of the user whose feedbacks are being deleted.</param>
+        /// <param name="courseId">The unique identifier of the course whose feedbacks are being deleted.</param>
+        /// <returns>A task that represents the asynchronous delete operation.</returns>
+        public async Task DeleteAllInCourseByUserId(string userId, Guid courseId)
+        {
+            var feedbacks = await FindAll()
+                .Where(f => f.UserId == userId && f.LMSActivity.Module.CourseId == courseId)
+                .ToListAsync();
+
+            if (!feedbacks.Any())
+                return;
+            
+            DeleteRange(feedbacks);
+        }
+    }
+}

--- a/LMS.Infractructure/Repositories/RepositoryBase.cs
+++ b/LMS.Infractructure/Repositories/RepositoryBase.cs
@@ -31,4 +31,6 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T>, IInternalRepositor
     public void Update(T entity) => DbSet.Update(entity);
 
     public void Delete(T entity) => DbSet.Remove(entity);
+
+    public void DeleteRange(IEnumerable<T> entities) => DbSet.RemoveRange(entities);
 }

--- a/LMS.Infractructure/Repositories/UnitOfWork.cs
+++ b/LMS.Infractructure/Repositories/UnitOfWork.cs
@@ -1,5 +1,7 @@
 ﻿using Domain.Contracts.Repositories;
+using Domain.Models.Entities;
 using LMS.Infractructure.Data;
+using Microsoft.AspNetCore.Identity;
 
 namespace LMS.Infractructure.Repositories;
 
@@ -17,24 +19,30 @@ public class UnitOfWork : IUnitOfWork
     private readonly Lazy<ILMSActivityRepository> _lmsActivityRepository;
     private readonly Lazy<IActivityTypeRepository> _activityTypeRepository;
     private readonly Lazy<IDocumentRepository> _documentRepository;
+    private readonly Lazy<ILMSActivityFeedbackRepository> _lmsActivityFeedbackRepository;
+    private readonly Lazy<IUserCourseRepository> _userCourseRepository;
 
-    public UnitOfWork(ApplicationDbContext context)
+    public IUserRepository User => _userRepository.Value;
+	public ICourseRepository Course => _courseRepository.Value;
+    public IModuleRepository Module => _moduleRepository.Value;
+    public ILMSActivityRepository LMSActivity => _lmsActivityRepository.Value;
+    public IActivityTypeRepository ActivityType => _activityTypeRepository.Value;
+    public IDocumentRepository Document => _documentRepository.Value;
+    public ILMSActivityFeedbackRepository LMSActivityFeedback => _lmsActivityFeedbackRepository.Value;
+    public IUserCourseRepository UserCourse => _userCourseRepository.Value;
+
+    public UnitOfWork(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
     {
         this.context = context ?? throw new ArgumentNullException(nameof(context));
-        _userRepository = new Lazy<IUserRepository>(() => new UserRepository(context));
+        _userRepository = new Lazy<IUserRepository>(() => new UserRepository(context, userManager));
         _courseRepository = new Lazy<ICourseRepository>(() => new CourseRepository(context));
         _moduleRepository = new Lazy<IModuleRepository>(() => new ModuleRepository(context));
         _lmsActivityRepository = new Lazy<ILMSActivityRepository>(() => new LMSActivityRepository(context));
         _activityTypeRepository = new Lazy<IActivityTypeRepository>(() => new ActivityTypeRepository(context));
         _documentRepository = new Lazy<IDocumentRepository>(() => new DocumentRepository(context));
+        _lmsActivityFeedbackRepository = new Lazy<ILMSActivityFeedbackRepository>(() => new LMSActivityFeedbackRepository(context));
+        _userCourseRepository = new Lazy<IUserCourseRepository>(() => new UserCourseRepository(context));
     }
-
-	  public IUserRepository User => _userRepository.Value;
-	  public ICourseRepository Course => _courseRepository.Value;
-    public IModuleRepository Module => _moduleRepository.Value;
-    public ILMSActivityRepository LMSActivity => _lmsActivityRepository.Value;
-    public IActivityTypeRepository ActivityType => _activityTypeRepository.Value;
-    public IDocumentRepository Document => _documentRepository.Value;
 
     public async Task CompleteAsync() => await context.SaveChangesAsync();
 }

--- a/LMS.Infractructure/Repositories/UserCourseRepository.cs
+++ b/LMS.Infractructure/Repositories/UserCourseRepository.cs
@@ -1,0 +1,38 @@
+﻿using Domain.Contracts.Repositories;
+using Domain.Models.Entities;
+using LMS.Infractructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LMS.Infractructure.Repositories
+{
+    /// <summary>
+    /// Repository implementation for managing <see cref="UserCourse"/> entities.
+    /// </summary>
+    public class UserCourseRepository : RepositoryBase<UserCourse>, IUserCourseRepository
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserCourseRepository"/> class with the specified database context.
+        /// </summary>
+        /// <param name="context">The database context to be used by the repository.</param>
+        public UserCourseRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Deletes all <see cref="UserCourse"/> entries associated with a specific user.
+        /// </summary>
+        /// <param name="studentId">The unique identifier of the user whose enrollments are being deleted.</param>
+        /// <returns>A task that represents the asynchronous delete operation.</returns>
+        public async Task DeleteAllByUserId(string studentId)
+        {
+            var enrollments = await FindAll()
+                .Where(enrollment => enrollment.UserId == studentId)
+                .ToListAsync();
+
+            if (!enrollments.Any())
+                return;
+            
+            DeleteRange(enrollments);
+        }
+    }
+}

--- a/LMS.Infractructure/Repositories/UserRepository.cs
+++ b/LMS.Infractructure/Repositories/UserRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Domain.Contracts.Repositories;
 using Domain.Models.Entities;
 using LMS.Infractructure.Data;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace LMS.Infractructure.Repositories;
@@ -14,11 +15,47 @@ namespace LMS.Infractructure.Repositories;
 /// </summary>
 public class UserRepository : RepositoryBase<ApplicationUser>, IUserRepository
 {
-	public UserRepository(ApplicationDbContext context): base(context)
-	{}
+    private readonly UserManager<ApplicationUser> _userManager;
 
-	// Not used yet. Parameters set to change.
-	void IRepositoryBase<ApplicationUser>.Create(ApplicationUser entity)
+    public UserRepository(ApplicationDbContext context, UserManager<ApplicationUser> userManager) : base(context)
+    {
+        _userManager = userManager;
+    }
+
+    /// <summary>
+    /// Checks if a user belongs to the "Teacher" role. <br/>
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains <c>true</c> if the user is a student; otherwise, <c>false</c>.</returns>
+    public async Task<bool> IsUserStudentAsync(string userId) =>
+        await IsUserInRoleAsync(userId, "Student");
+
+    /// <summary>
+    /// Checks if a user belongs to the "Teacher" role. <br/>
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains <c>true</c> if the user is a teacher; otherwise, <c>false</c>.</returns>
+    public async Task<bool> IsUserTeacherAsync(string userId) => 
+        await IsUserInRoleAsync(userId, "Teacher");
+
+    /// <summary>
+    /// Checks if a user belongs to a specific role. <br/>
+    /// </summary>
+    /// <param name="userId">The unique identifier of the user.</param>
+    /// <param name="roleName">The name of the role to check.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains <c>true</c> if the user is in the specified role; otherwise, <c>false</c>.</returns>
+    private async Task<bool> IsUserInRoleAsync(string userId, string roleName)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+
+        if (user == null)
+            return false;
+
+        return await _userManager.IsInRoleAsync(user, roleName);
+    }
+
+    // Not used yet. Parameters set to change.
+    void IRepositoryBase<ApplicationUser>.Create(ApplicationUser entity)
 	{
 		throw new NotImplementedException();
 	}

--- a/LMS.Presentation/Controllers/CourseController.cs
+++ b/LMS.Presentation/Controllers/CourseController.cs
@@ -131,4 +131,61 @@ public class CourseController: ControllerBase
 		var createdCourse = await _serviceManager.CourseService.CreateCourseAsync(createCourseDto);
 		return CreatedAtAction(nameof(GetCourse), new { Guid = createdCourse.Id }, createdCourse);
 	}
+
+    /// <summary>
+    /// Enrolls a student into a specific course.
+    /// </summary>
+    /// <remarks>Must be authorized as a <c>Teacher</c> to access this endpoint.</remarks>
+    /// <param name="courseId">The unique identifier of the course.</param>
+    /// <param name="studentId">The unique identifier of the student to enroll.</param>
+    /// <response code="204">Student was successfully enrolled in the course.</response>
+    /// <response code="400">Invalid request (e.g., student already enrolled).</response>
+    /// <response code="401">Unauthorized.</response>
+    /// <response code="403">Forbidden.</response>
+    /// <response code="404">Course or student not found.</response>
+    [HttpPost("{courseId:guid}/participants/{studentId:guid}")]
+    [Authorize(Roles = "Teacher")]
+    [SwaggerOperation(
+        Summary = "Enroll a student into a course",
+        Description = "Adds the specified student to the participants list of the course. Requires Teacher role."
+    )]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    public async Task<IActionResult> EnrollStudent(Guid courseId, Guid studentId)
+    {
+        await _serviceManager.CourseService.EnrollStudentAsync(courseId, studentId.ToString());
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Unenrolls a student from a specific course.
+    /// </summary>
+    /// <remarks>Must be authorized as a <c>Teacher</c> to access this endpoint. 
+    /// When a student is removed, all their submitted feedback for this course will also be deleted.</remarks>
+    /// <param name="courseId">The unique identifier of the course.</param>
+    /// <param name="studentId">The unique identifier of the student to unenroll.</param>
+    /// <response code="204">Student was successfully unenrolled from the course.</response>
+    /// <response code="400">Invalid request (e.g., student not enrolled).</response>
+    /// <response code="401">Unauthorized.</response>
+    /// <response code="403">Forbidden.</response>
+    /// <response code="404">Course or student not found.</response>
+    [HttpDelete("{courseId:guid}/participants/{studentId:guid}")]
+    [Authorize(Roles = "Teacher")]
+    [SwaggerOperation(
+        Summary = "Unenroll a student from a course",
+        Description = "Removes the specified student from the participants list of the course and deletes all their feedback related to the course. Requires Teacher role."
+    )]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    public async Task<IActionResult> UnenrollStudent(Guid courseId, Guid studentId)
+    {
+        await _serviceManager.CourseService.UnenrollStudentAsync(courseId, studentId.ToString());
+        return NoContent();
+    }
 }

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -128,7 +128,7 @@ public class CourseService : ICourseService
             throw new UserNotFoundException(studentId);
 
         if (!await _unitOfWork.User.IsUserStudentAsync(studentId))
-          throw new RoleMismatchException("User role must be a Student to perform enrollment in a course.");
+          throw new RoleMismatchException("User with provided ID is not a Student.");
 
         if (course.UserCourses.Any(uc => uc.UserId == studentId))
           return;
@@ -154,7 +154,7 @@ public class CourseService : ICourseService
             throw new UserNotFoundException(studentId);
 
         if (!await _unitOfWork.User.IsUserStudentAsync(studentId))
-            throw new RoleMismatchException("User role must be a Student to perform unenrollment from a course.");
+            throw new RoleMismatchException("User with provided ID is not a Student.");
 
         await _unitOfWork.UserCourse.DeleteAllByUserId(studentId);
       await _unitOfWork.LMSActivityFeedback.DeleteAllInCourseByUserId(studentId, courseId);

--- a/LMS.Services/CourseService.cs
+++ b/LMS.Services/CourseService.cs
@@ -124,10 +124,13 @@ public class CourseService : ICourseService
       if (course is null)
           throw new CourseNotFoundException(courseId);
 
-      if (!await _unitOfWork.User.IsUserStudentAsync(studentId))
-          throw new UserNotFoundException(studentId);
+      if (await _unitOfWork.User.GetUserAsync(studentId) is null)
+            throw new UserNotFoundException(studentId);
 
-      if (course.UserCourses.Any(uc => uc.UserId == studentId))
+        if (!await _unitOfWork.User.IsUserStudentAsync(studentId))
+          throw new RoleMismatchException("User role must be a Student to perform enrollment in a course.");
+
+        if (course.UserCourses.Any(uc => uc.UserId == studentId))
           return;
 
       _unitOfWork.UserCourse.Create(new UserCourse { UserId = studentId, CourseId = courseId });
@@ -147,10 +150,13 @@ public class CourseService : ICourseService
       if (course is null)
           throw new CourseNotFoundException(courseId);
 
-      if (!await _unitOfWork.User.IsUserStudentAsync(studentId))
-          throw new UserNotFoundException(studentId);
+        if (await _unitOfWork.User.GetUserAsync(studentId) is null)
+            throw new UserNotFoundException(studentId);
 
-      await _unitOfWork.UserCourse.DeleteAllByUserId(studentId);
+        if (!await _unitOfWork.User.IsUserStudentAsync(studentId))
+            throw new RoleMismatchException("User role must be a Student to perform unenrollment from a course.");
+
+        await _unitOfWork.UserCourse.DeleteAllByUserId(studentId);
       await _unitOfWork.LMSActivityFeedback.DeleteAllInCourseByUserId(studentId, courseId);
 
       await _unitOfWork.CompleteAsync();

--- a/Service.Contracts/ICourseService.cs
+++ b/Service.Contracts/ICourseService.cs
@@ -40,4 +40,20 @@ public interface ICourseService
 	/// <param name="name">Name to check.</param>
 	/// <returns>Boolean indicating if the name is already in use.</returns>
 	Task<bool> IsNotUniqueCourseNameAsync(string name);
+
+    /// <summary>
+    /// Enrolls a student into the specified course.
+    /// </summary>
+    /// <param name="courseId">The unique identifier of the course.</param>
+    /// <param name="studentId">The unique identifier of the student to enroll.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task EnrollStudentAsync(Guid courseId, string studentId);
+
+    /// <summary>
+    /// Unenrolls a student from the specified course and removes all their related feedback.
+    /// </summary>
+    /// <param name="courseId">The unique identifier of the course.</param>
+    /// <param name="studentId">The unique identifier of the student to unenroll.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task UnenrollStudentAsync(Guid courseId, string studentId);
 }


### PR DESCRIPTION
This PR introduces two new endpoints in the CourseController to allow Teachers to manage course participants:

1. Enroll a student in a course

- Endpoint: POST /api/course/{courseId}/participants/{studentId}
- Access: Teacher only
- Behavior: Adds the specified student to the course's participants list (if provided user to enroll is a teacher throws 404).

2. Unenroll a student from a course

- Endpoint: DELETE /api/course/{courseId}/participants/{studentId}
- Access: Teacher only
- Behavior: Removes the student from the course's participants list (if provided user to enroll is a teacher throws 404).
- Additional behavior: All feedback submitted by the student for this course is also deleted.